### PR TITLE
use temporary roles to notify event participants

### DIFF
--- a/TTBot/Models/Event.cs
+++ b/TTBot/Models/Event.cs
@@ -13,6 +13,7 @@ namespace TTBot.Models
         public string ShortName { get; set; }
         public string GuildId { get; set; }
         public string ChannelId { get; set; }
+        public string RoleId { get; set; }
         public bool Closed { get; set; }
         public int? Capacity { get; set; }
         [Ignore]

--- a/TTBot/Program.cs
+++ b/TTBot/Program.cs
@@ -100,6 +100,21 @@ namespace TTBot
             }
 
 
+            if (reaction.User.Value is IGuildUser guildUser)
+            {
+                var role = guildUser.Guild.Roles.FirstOrDefault(x => x.Id.ToString() == @event.RoleId);
+                if (role != null)
+                {
+                    /* no effect if user doesn' have the role anymore */
+                    try
+                    {
+                        await guildUser.RemoveRoleAsync(role);
+                    }
+                    catch (Discord.Net.HttpException) { /* ignore forbidden exception */ }
+                    
+                }
+            }
+
             await eventSignups.Delete(existingSignup);
             await eventParticipantSets.UpdatePinnedMessageForEvent(channel, @event, message);
             await reaction.User.Value.SendMessageAsync($"Thanks! You've been removed from {@event.Name}.");
@@ -158,6 +173,21 @@ namespace TTBot
             {
                 await CancelSignup($"Sorry, {reaction.User.Value.Mention} this event is currently full!");
                 return;
+            }
+
+
+            if(reaction.User.Value is IGuildUser guildUser)
+            {
+                var role = guildUser.Guild.Roles.FirstOrDefault(x => x.Id.ToString() == @event.RoleId);
+                if (role != null)
+                {
+                    try
+                    {
+                        await guildUser.AddRoleAsync(role);
+                    }
+                    catch (Discord.Net.HttpException) { /* ignore forbidden exception */ }
+                        
+                }
             }
 
             await eventSignups.AddUserToEvent(@event, reaction.User.Value);


### PR DESCRIPTION
As discussed before, this introduces temporary roles for easier client notifications.

• On event creation, the bot creates a new role, `shortName + " notify"`. This role can be used to mention all race participants.
• Users are getting assign/unissagned on register/unregister.
• When the event is closed, the role is deleted

All role-related methods are safe for permission errors, aswell as scenarios where the role was deleted by a moderator.
If the `RoleId` is not assigned in the database, it is considered as if the role was deleted by a moderator (=>no action taken)



### Not resolved
Database migration. Existing sqlite databases might need a migration script.