### PR TITLE
sending DM to server owner on sign out/in

### DIFF
--- a/TTBot/Commands/EventModule.cs
+++ b/TTBot/Commands/EventModule.cs
@@ -161,6 +161,9 @@ namespace TTBot.Commands
                 return;
             }
 
+
+            string nickName = Context.Message.Author.Username;
+
             if (Context.Message.Author is IGuildUser guildUser)
             {
                 var role = guildUser.Guild.Roles.FirstOrDefault(x => x.Id.ToString() == existingEvent.RoleId);
@@ -172,9 +175,13 @@ namespace TTBot.Commands
                     }
                     catch (Discord.Net.HttpException) { /* ignore forbidden exception */ }
                 }
+
+                nickName = string.IsNullOrEmpty(guildUser.Nickname) ? nickName : guildUser.Nickname;
             }
 
+
             await _eventSignups.AddUserToEvent(existingEvent, Context.Message.Author as SocketGuildUser);
+            await Context.Guild.Owner.SendMessageAsync($"{nickName} signed up to {existingEvent.Name}");
             await Context.Message.Author.SendMessageAsync($"Thanks {Context.Message.Author.Mention}! You've been signed up to {existingEvent.Name}. You can check the pinned messages in the event's channel to see the list of participants.");
             await UpdateConfirmationCheckForEvent(existingEvent);
             await _eventParticipantService.UpdatePinnedMessageForEvent(Context.Channel, existingEvent);
@@ -197,7 +204,10 @@ namespace TTBot.Commands
                 return;
             }
 
-            if(Context.Message.Author is IGuildUser guildUser)
+
+            string nickName = Context.Message.Author.Username;
+
+            if (Context.Message.Author is IGuildUser guildUser)
             {
                 var role = guildUser.Guild.Roles.FirstOrDefault(x => x.Id.ToString() == existingEvent.RoleId);
                 if (role != null)
@@ -209,9 +219,12 @@ namespace TTBot.Commands
                     }
                     catch (Discord.Net.HttpException) { /* ignore forbidden exception */ }
                 }
+
+                nickName = string.IsNullOrEmpty(guildUser.Nickname) ? nickName : guildUser.Nickname;
             }
 
             await _eventSignups.DeleteAsync(existingSignup);
+            await Context.Guild.Owner.SendMessageAsync($"{nickName} signed out of {existingEvent.Name}");
             await Context.Channel.SendMessageAsync($"Thanks { Context.Message.Author.Mention}! You're no longer signed up to {existingEvent.Name}.");
             await UpdateConfirmationCheckForEvent(existingEvent);
             await _eventParticipantService.UpdatePinnedMessageForEvent(Context.Channel, existingEvent);

--- a/TTBot/Program.cs
+++ b/TTBot/Program.cs
@@ -16,6 +16,7 @@ using ServiceStack.OrmLite;
 using TTBot.Models;
 using ServiceStack.Data;
 using System.Collections.Generic;
+using ServiceStack.Model;
 
 namespace TTBot
 {
@@ -100,6 +101,8 @@ namespace TTBot
             }
 
 
+            string nickName = reaction.User.Value.Username;
+
             if (reaction.User.Value is IGuildUser guildUser)
             {
                 var role = guildUser.Guild.Roles.FirstOrDefault(x => x.Id.ToString() == @event.RoleId);
@@ -113,10 +116,17 @@ namespace TTBot
                     catch (Discord.Net.HttpException) { /* ignore forbidden exception */ }
                     
                 }
-            }        
+
+                nickName = string.IsNullOrEmpty(guildUser.Nickname) ? nickName : guildUser.Nickname;
+            }
+
+
+            if (channel is SocketTextChannel textChannel)
+            {
+                await textChannel.Guild.Owner.SendMessageAsync($"{nickName} signed out of {@event.Name}");
+            }
 
             await eventSignups.DeleteAsync(existingSignup);
-
             await eventParticipantSets.UpdatePinnedMessageForEvent(channel, @event, message);
             await reaction.User.Value.SendMessageAsync($"Thanks! You've been removed from {@event.Name}.");
 
@@ -177,6 +187,8 @@ namespace TTBot
             }
 
 
+            var nickName = reaction.User.Value.Username;
+
             if(reaction.User.Value is IGuildUser guildUser)
             {
                 var role = guildUser.Guild.Roles.FirstOrDefault(x => x.Id.ToString() == @event.RoleId);
@@ -189,10 +201,20 @@ namespace TTBot
                     catch (Discord.Net.HttpException) { /* ignore forbidden exception */ }
                         
                 }
+
+                nickName = string.IsNullOrEmpty(guildUser.Nickname) ? nickName : guildUser.Nickname;
             }
 
             await eventSignups.AddUserToEvent(@event, reaction.User.Value);
             await eventParticipantSets.UpdatePinnedMessageForEvent(channel, @event, message);
+
+            
+
+            if(channel is SocketTextChannel textChannel)
+            {
+                await textChannel.Guild.Owner.SendMessageAsync($"{nickName} signed up to {@event.Name}");
+            }
+
             await reaction.User.Value.SendMessageAsync($"Thanks! You've been signed up to {@event.Name}. If you can no longer attend just remove your reaction from the signup message!");
         }
 


### PR DESCRIPTION
Here's the implementation.
Currently it gets the server owner, but maybe we could add a settings in the moderation section?
Or maybe a feature expansion to toggle  sign in/out seperate with a command.